### PR TITLE
style: add `simple-import-sort/sort` rule to eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,9 @@
 {
-  "extends": ["react-app", "plugin:prettier/recommended"],
+  "extends": ["eslint:recommended", "react-app"],
+  "plugins": ["eslint-plugin-simple-import-sort", "prettier"],
   "rules": {
-    "no-unused-vars": ["error"],
-    "prettier/prettier": ["error"],
-    "@typescript-eslint/consistent-type-definitions": ["error", "interface"]
+    "@typescript-eslint/consistent-type-definitions": ["error", "interface"],
+    "prettier/prettier": "error",
+    "simple-import-sort/sort": "error"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "coveralls": "^3.0.9",
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-prettier": "^3.1.2",
+    "eslint-plugin-simple-import-sort": "^5.0.0",
     "husky": "^4.0.6",
     "lint-staged": "^9.5.0",
     "mockdate": "^2.0.5",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+
 import App from './App';
 
 it('renders without crashing', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
+import './App.css';
+
 import CssBaseline from '@material-ui/core/CssBaseline';
+import React from 'react';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 
-import Header from './components/Header';
-import { FirebaseProvider } from './components/Firebase';
-import { firebaseConfig } from './constants';
-import './App.css';
-import Boards from './components/Boards';
 import Board from './components/Board';
+import Boards from './components/Boards';
 import ErrorPage from './components/ErrorPage';
+import { FirebaseProvider } from './components/Firebase';
+import Header from './components/Header';
+import { firebaseConfig } from './constants';
 
 const App: React.FC = () => {
   return (

--- a/src/components/Board/Board.stories.tsx
+++ b/src/components/Board/Board.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import Board from './Board';
+
 import { noop } from '../../constants';
+import Board from './Board';
 
 export default {
   title: 'Board',

--- a/src/components/Board/Board.styles.tsx
+++ b/src/components/Board/Board.styles.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { styled } from '@material-ui/core/styles';
 import Fab, { FabProps } from '@material-ui/core/Fab';
-import AddIcon from '@material-ui/icons/Add';
 import { IconProps } from '@material-ui/core/Icon/Icon';
+import { styled } from '@material-ui/core/styles';
+import AddIcon from '@material-ui/icons/Add';
+import React from 'react';
 
 type AddButtonProps = FabProps & {
   spacing: number;

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -1,12 +1,11 @@
+import Box from '@material-ui/core/Box';
+import Divider from '@material-ui/core/Divider';
+import Grid from '@material-ui/core/Grid';
+import { useTheme } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
 import React from 'react';
 
-import Box from '@material-ui/core/Box';
-import Grid from '@material-ui/core/Grid';
-import Divider from '@material-ui/core/Divider';
-import { useTheme } from '@material-ui/core/styles';
 import { CardsDocumentData } from '../../lib/hooks/useCards';
-import Typography from '@material-ui/core/Typography';
-
 import Tile from '../Tile';
 import * as S from './Board.styles';
 

--- a/src/components/Board/BoardContainer.test.tsx
+++ b/src/components/Board/BoardContainer.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import useGroup, { UseGroupResult } from '../../lib/hooks/useGroup';
+
 import useCards, { UseCardsResult } from '../../lib/hooks/useCards';
-import BoardContainer from './BoardContainer';
-import { GroupType } from '../../lib/types';
+import useGroup, { UseGroupResult } from '../../lib/hooks/useGroup';
 import renderWithRouter from '../../lib/test/renderWithRouter';
+import { GroupType } from '../../lib/types';
+import BoardContainer from './BoardContainer';
 
 jest.mock('../../lib/hooks/useGroup');
 jest.mock('../../lib/hooks/useCards');

--- a/src/components/Board/BoardContainer.tsx
+++ b/src/components/Board/BoardContainer.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import Board from './Board';
-import useGroup from '../../lib/hooks/useGroup';
-import useCards from '../../lib/hooks/useCards';
 import { Redirect } from 'react-router-dom';
+
 import useAddCard from '../../lib/hooks/useAddCard';
+import useCards from '../../lib/hooks/useCards';
+import useGroup from '../../lib/hooks/useGroup';
+import Board from './Board';
 
 interface Props {
   match: {

--- a/src/components/Boards/Boards.stories.tsx
+++ b/src/components/Boards/Boards.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import Boards from './Boards';
+
 import { noop } from '../../constants';
+import Boards from './Boards';
 
 export default {
   title: 'Boards',

--- a/src/components/Boards/Boards.styles.tsx
+++ b/src/components/Boards/Boards.styles.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { styled } from '@material-ui/core/styles';
 import Fab, { FabProps } from '@material-ui/core/Fab';
-import AddIcon from '@material-ui/icons/Add';
 import { IconProps } from '@material-ui/core/Icon/Icon';
+import { styled } from '@material-ui/core/styles';
+import AddIcon from '@material-ui/icons/Add';
+import React from 'react';
 
 type AddButtonProps = FabProps & {
   spacing: number;

--- a/src/components/Boards/Boards.tsx
+++ b/src/components/Boards/Boards.tsx
@@ -1,13 +1,12 @@
-import React from 'react';
-
 import Box from '@material-ui/core/Box';
 import Divider from '@material-ui/core/Divider';
 import Grid from '@material-ui/core/Grid';
 import { useTheme } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
+import React from 'react';
 
-import * as S from './Boards.styles';
 import Tile from '../Tile';
+import * as S from './Boards.styles';
 
 interface Props {
   boards: {

--- a/src/components/Boards/BoardsContainer.test.tsx
+++ b/src/components/Boards/BoardsContainer.test.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import useGroups, { UseGroupsResult } from '../../lib/hooks/useGroups';
-import { MemoryRouter } from 'react-router';
-import Boards from './BoardsContainer';
 import { render } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+
+import useGroups, { UseGroupsResult } from '../../lib/hooks/useGroups';
+import Boards from './BoardsContainer';
 
 jest.mock('../../lib/hooks/useGroups', () => jest.fn());
 jest.mock('../../lib/hooks/useUpdateGroups', () => jest.fn());

--- a/src/components/Boards/BoardsContainer.tsx
+++ b/src/components/Boards/BoardsContainer.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import Boards from './Boards';
+
 import useGroups from '../../lib/hooks/useGroups';
 import useUpdateGroups from '../../lib/hooks/useUpdateGroups';
 import { GroupType } from '../../lib/types';
+import Boards from './Boards';
 
 export default function BoardsContainer() {
   const { data, loading, error } = useGroups();

--- a/src/components/ErrorPage/ErrorPage.stories.tsx
+++ b/src/components/ErrorPage/ErrorPage.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import ErrorPage from './ErrorPage';
 
 export default {

--- a/src/components/ErrorPage/ErrorPage.tsx
+++ b/src/components/ErrorPage/ErrorPage.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
+import React from 'react';
+import { Link } from 'react-router-dom';
 
 export default function ErrorPage() {
   return (

--- a/src/components/Firebase/Firebase.test.tsx
+++ b/src/components/Firebase/Firebase.test.tsx
@@ -1,8 +1,10 @@
-import firebase from 'firebase/app';
 import 'firebase/auth';
+
+import firebase from 'firebase/app';
 import React, { useContext } from 'react';
 import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
+
 import { firebaseConfig } from '../../constants';
 import { FirebaseContext, FirebaseProvider } from './Firebase';
 

--- a/src/components/Firebase/Firebase.tsx
+++ b/src/components/Firebase/Firebase.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from 'react';
-import firebase from 'firebase/app';
 import 'firebase/auth';
 import 'firebase/firestore';
+
+import firebase from 'firebase/app';
+import React, { useEffect, useState } from 'react';
 
 export const FirebaseContext = React.createContext({
   firebase: {},

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
-import Toolbar from '@material-ui/core/Toolbar';
-import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import Toolbar from '@material-ui/core/Toolbar';
+import Typography from '@material-ui/core/Typography';
 import MenuIcon from '@material-ui/icons/Menu';
+import React from 'react';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/src/components/Tile/Tile.stories.tsx
+++ b/src/components/Tile/Tile.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import Tile from './Tile';
 
 export default {

--- a/src/components/Tile/Tile.tsx
+++ b/src/components/Tile/Tile.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
-import CardActions from '@material-ui/core/CardActions';
-import Button from '@material-ui/core/Button';
-import Grid from '@material-ui/core/Grid';
-import CardHeader from '@material-ui/core/CardHeader';
 import Avatar from '@material-ui/core/Avatar';
-import CardActionArea from '@material-ui/core/CardActionArea';
+import Button from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
+import CardActionArea from '@material-ui/core/CardActionArea';
+import CardActions from '@material-ui/core/CardActions';
+import CardHeader from '@material-ui/core/CardHeader';
+import Grid from '@material-ui/core/Grid';
+import React from 'react';
+
 import * as S from './Tile.styles';
 
 interface Props {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,8 @@
+import './index.css';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
-import './index.css';
+
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 

--- a/src/lib/hooks/useAddCard.ts
+++ b/src/lib/hooks/useAddCard.ts
@@ -1,4 +1,5 @@
 import { useContext } from 'react';
+
 import { FirebaseContext } from '../../components/Firebase';
 
 export default function(options?: { client?: typeof firebase }) {

--- a/src/lib/hooks/useCards.ts
+++ b/src/lib/hooks/useCards.ts
@@ -1,7 +1,8 @@
 import { useContext } from 'react';
+import { useCollection } from 'react-firebase-hooks/firestore';
+
 import { FirebaseContext } from '../../components/Firebase';
 import { CollectionQueryResult } from '../types';
-import { useCollection } from 'react-firebase-hooks/firestore';
 
 export interface CardsDocumentData {
   id: string;

--- a/src/lib/hooks/useGroup.ts
+++ b/src/lib/hooks/useGroup.ts
@@ -1,7 +1,8 @@
 import { useContext } from 'react';
+import { useDocument } from 'react-firebase-hooks/firestore';
+
 import { FirebaseContext } from '../../components/Firebase';
 import { DocumentQueryResult } from '../types';
-import { useDocument } from 'react-firebase-hooks/firestore';
 
 interface GroupDocumentData {
   id: string;

--- a/src/lib/hooks/useGroups.test.ts
+++ b/src/lib/hooks/useGroups.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import firebase from 'firebase/app';
+
 import { firebaseConfig } from '../../constants';
 import useGroups from './useGroups';
 

--- a/src/lib/hooks/useGroups.ts
+++ b/src/lib/hooks/useGroups.ts
@@ -1,7 +1,8 @@
 import { useContext } from 'react';
+import { useCollection } from 'react-firebase-hooks/firestore';
+
 import { FirebaseContext } from '../../components/Firebase';
 import { CollectionQueryResult, GroupType } from '../types';
-import { useCollection } from 'react-firebase-hooks/firestore';
 
 interface GroupsDocumentData {
   id: string;

--- a/src/lib/hooks/useUpdateGroups.ts
+++ b/src/lib/hooks/useUpdateGroups.ts
@@ -1,4 +1,5 @@
 import { useContext } from 'react';
+
 import { FirebaseContext } from '../../components/Firebase';
 import { GroupType } from '../types';
 

--- a/src/lib/test/renderWithRouter.tsx
+++ b/src/lib/test/renderWithRouter.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { createMemoryHistory, MemoryHistory } from 'history';
-import { Router } from 'react-router';
 import { render } from '@testing-library/react';
+import { createMemoryHistory, MemoryHistory } from 'history';
+import React from 'react';
+import { Router } from 'react-router';
 
 export default function renderWithRouter(
   ui: React.ReactElement,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6165,6 +6165,11 @@ eslint-plugin-react@7.16.0:
     prop-types "^15.7.2"
     resolve "^1.12.0"
 
+eslint-plugin-simple-import-sort@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-5.0.0.tgz#fd2abac52c0ae6050baf340c004b0b5d9aa76e8e"
+  integrity sha512-Zn6OppySnbwl/UonkzmMBbiFXZwe/tI9ZlSXwQek5h1FfPv3hcDTE3kG0SC70pBsKuVE8IMwZCMl0tKwcY89rw==
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"


### PR DESCRIPTION
This will allow easy autofixable import sorting

See [eslint-plugin-simple-import-sort](https://www.npmjs.com/package/eslint-plugin-simple-import-sort)

This depends on #42